### PR TITLE
Extend db creation script with profile fields

### DIFF
--- a/db-create.php
+++ b/db-create.php
@@ -8,10 +8,27 @@ $createUsers = "CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     username VARCHAR(255) UNIQUE NOT NULL,
     password VARCHAR(255) NOT NULL,
-    role VARCHAR(50) NOT NULL
+    role VARCHAR(50) NOT NULL,
+    nickname VARCHAR(255) DEFAULT NULL,
+    about_me TEXT DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
 
 $pdo->exec($createUsers);
+
+// Add new profile columns if they don't exist
+function columnExists(PDO $pdo, string $table, string $column): bool {
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?");
+    $stmt->execute([$table, $column]);
+    return $stmt->fetchColumn() > 0;
+}
+
+if (!columnExists($pdo, 'users', 'nickname')) {
+    $pdo->exec("ALTER TABLE users ADD COLUMN nickname VARCHAR(255) DEFAULT NULL");
+}
+
+if (!columnExists($pdo, 'users', 'about_me')) {
+    $pdo->exec("ALTER TABLE users ADD COLUMN about_me TEXT DEFAULT NULL");
+}
 
 // Insert default admin user
 $hash = password_hash('admin', PASSWORD_DEFAULT);


### PR DESCRIPTION
## Summary
- expand `users` table with `nickname` and `about_me`
- update existing databases by adding the new columns if missing

## Testing
- `php -l db-create.php` *(fails: `php` not installed)*