### PR TITLE
Fix header layout override

### DIFF
--- a/css/albums.css
+++ b/css/albums.css
@@ -63,12 +63,7 @@ header {
   src: url('../shrifts/Nordicablack-Xa39.otf');
 }
 
-.header_inner{
-    width: 100%;
-    height: fit-content;
-    position: absolute;
-    opacity: 0.5;
-}
+
 
 .layer {
    background: url('../img/boat-main.jpg') no-repeat center center;

--- a/css/musica.css
+++ b/css/musica.css
@@ -63,12 +63,7 @@ header {
   src: url('../shrifts/Nordicablack-Xa39.otf');
 }
 
-.header_inner{
-    width: 100%;
-    height: fit-content;
-    position: absolute;
-    opacity: 0.5;
-}
+
 
 .layer {
    background: url('../img/boat-main.jpg') no-repeat center center;


### PR DESCRIPTION
## Summary
- remove `.header_inner` overrides from `musica.css` and `albums.css`
- let `styles.css` handle header layout consistently across pages

## Testing
- `git status --short`